### PR TITLE
PR Phase 2(docs): sync structure tree with current layout and trim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Built with **FastAPI**, **SQLAlchemy**, and **PostgreSQL**, Cost Query Pro is de
 | Branch   | Build Status                                                                                                                                                                                                              | Python                                                                                    | Framework                                                                                   | License                                                            | Project Status                                                         |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | **main** | [![Main Build](https://github.com/Brice-Engineering-Projects/Cost-Query-Pro/actions/workflows/ci-cd.yml/badge.svg?branch=main)](https://github.com/Brice-Engineering-Projects/Cost-Query-Pro/actions/workflows/ci-cd.yml) | ![Python 3.12](https://img.shields.io/badge/Python-3.12-blue?logo=python&logoColor=white) | ![FastAPI](https://img.shields.io/badge/FastAPI-Backend-green?logo=fastapi&logoColor=white) | ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg) | ![Status](https://img.shields.io/badge/Status-In%20Development-orange) |
-| **dev**  | [![Dev Build](https://github.com/Brice-Engineering-Projects/Cost-Query-Pro/actions/workflows/ci-cd.yml/badge.svg?branch=dev)](https://github.com/Brice-Engineering-Projects/Cost-Query-Pro/actions/workflows/ci-cd.yml)   | ![Python 3.12](https://img.shields.io/badge/Python-3.12-blue?logo=python&logoColor=white) | ![FastAPI](https://img.shields.io/badge/FastAPI-Backend-green?logo=fastapi&logoColor=white) | ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg) | ![Status](https://img.shields.io/badge/Status-In%20Development-orange) |
 
 **Version:** v0.1.0
 **Status:** Early Release (MVP)
@@ -85,53 +84,8 @@ Visit `http://localhost:8000/docs`
 
 ### 📂 Project Structure
 
-```graphql
-cost_query_pro/
-│
-├── app/                      # Main application code
-│   ├── __init__.py
-│   ├── main.py               # FastAPI app entry point
-│   ├── models/               # SQLAlchemy models
-│   │    └── __init__.py
-│   ├── db/                   # Database config and session utilities
-│   │    └── __init__.py
-│   ├── api/                  # API route definitions
-│   │    ├── __init__.py
-│   │    ├── auth.py
-│   │    ├── projects.py
-│   │    ├── items.py
-│   │    └── purge.py
-│   ├── config/                 # Configuration files
-│   │    ├── __init__.py        # initialization file
-│   │    └── settings.py        # settings file
-│   ├── core/                 # Core logic/utilities (e.g. purge scripts)
-│   │    ├── __init__.py
-│   │    ├── security.py
-│   │    └── data_upload.py
-│   ├── schemas/              # Pydantic schemas for API validation
-│   │    └── __init__.py
-│   ├── templates/            # HTML templates (if using Jinja2)
-│   │    └── ...
-│   ├── static/               # CSS, JS, images (if applicable)
-│   │    └── ...
-│   └── services/             # Business logic services
-│        └── __init__.py
-│
-├── migrations/               # DB migrations (e.g. Alembic)
-│
-├── tests/                    # Unit and integration tests
-│   ├── __init__.py
-│   ├── test_projects.py
-│   ├── test_items.py
-│   └── test_auth.py
-│
-├── .env                      # Environment variables (never commit secrets!)
-├── .gitignore
-├── uv.lock                   # Locked dependencies managed by uv
-├── README.md
-├── LICENSE
-└── pyproject.toml            # Project metadata and dependency declarations
-```
+The full annotated directory tree lives in
+[`docs/01_architecture/00_structure.md`](docs/01_architecture/00_structure.md).
 
 ---
 

--- a/docs/01_architecture/00_structure.md
+++ b/docs/01_architecture/00_structure.md
@@ -5,28 +5,33 @@ cost_query_pro/
 ├── src/
 │   └── cost_query_pro/                        # Main application package
 │        ├── __init__.py
-│        ├── main.py                           # FastAPI app entry point
+│        ├── main.py                           # FastAPI app entry point, router wiring, error handlers
 │        │
 │        ├── api/                              # API route definitions
 │        │    ├── __init__.py
-│        │    ├── auth.py
-│        │    ├── projects.py
+│        │    ├── admin_users.py               # Admin-only user management endpoints
+│        │    ├── agent.py                     # POST /agent/query — natural language cost search
+│        │    ├── auth.py                      # Login / token endpoints
+│        │    ├── ingest.py                    # CSV/Excel upload endpoint
 │        │    ├── items.py
-│        │    └── purge.py
+│        │    ├── projects.py
+│        │    └── purge.py                     # Archive/purge maintenance endpoints
 │        │
 │        ├── config/                           # Configuration management
 │        │    ├── __init__.py
+│        │    ├── pricing.py                   # Per-model LLM token rates for cost estimates
+│        │    ├── prompts.py                   # Domain system prompt + PROMPT_VERSION
 │        │    └── settings.py                  # Environment and settings config
 │        │
 │        ├── core/                             # Core logic and system utilities
 │        │    ├── __init__.py
-│        │    ├── security.py                  # JWT, password hashing, auth helpers
-│        │    └── data_upload.py               # Data upload + validation logic
+│        │    ├── errors.py                    # AppError structured error class
+│        │    └── security.py                  # JWT, password hashing, auth helpers
 │        │
 │        ├── db/                               # Database setup and session control
 │        │    ├── __init__.py
-│        │    ├── base.py                      # SQLAlchemy Base and metadata
-│        │    └── session.py                   # Database engine and session factory
+│        │    ├── base.py                      # SQLAlchemy DeclarativeBase
+│        │    └── session.py                   # Database engine, session factory, get_db
 │        │
 │        ├── deps/                             # Dependency injection modules
 │        │    ├── __init__.py
@@ -39,6 +44,7 @@ cost_query_pro/
 │        │    ├── audit_log.py
 │        │    ├── data_quality_issue.py
 │        │    ├── item.py
+│        │    ├── llm_usage.py                 # Per-completion token usage and cost
 │        │    ├── project.py
 │        │    ├── system_setting.py
 │        │    ├── upload_history.py
@@ -46,7 +52,9 @@ cost_query_pro/
 │        │
 │        ├── schemas/                          # Pydantic models for validation
 │        │    ├── __init__.py
+│        │    ├── agent.py                     # SearchParameters, CostSummary, agent request/response
 │        │    ├── auth.py
+│        │    ├── ingest.py
 │        │    ├── item.py
 │        │    ├── project.py
 │        │    ├── token.py
@@ -54,43 +62,88 @@ cost_query_pro/
 │        │
 │        ├── services/                         # Business logic / service layer
 │        │    ├── __init__.py
-│        │    ├── auth_service.py
-│        │    ├── item_service.py
-│        │    └── project_service.py
+│        │    ├── agent_tools.py               # Tool definitions + handlers for the agent
+│        │    ├── analytics.py                 # Pipeline step 3 — aggregate cost statistics
+│        │    ├── ingestion.py                 # CSV/Excel parsing, validation, persistence
+│        │    ├── intent_parser.py             # Pipeline step 1 — question → SearchParameters
+│        │    ├── item_search.py               # Pipeline step 2 — SearchParameters → DB query
+│        │    ├── llm_provider.py              # Claude primary / OpenAI fallback abstraction
+│        │    ├── response_generator.py        # Pipeline steps 4-5 — sanitize + generate answer
+│        │    └── usage_recorder.py            # Writes llm_usage rows
 │        │
-│        ├── templates/                        # Global Jinja2 templates (Bootstrap-based)
+│        ├── templates/                        # Jinja2 templates (Bootstrap-based)
 │        │    ├── base.html
-│        │    ├── dashboard.html
-│        │    └── login.html
-│        │
-│        ├── static/                           # Static assets (CSS, JS, images)
-│        │    └── ...
+│        │    └── dashboard.html
 │        │
 │        └── web/                              # Web views and Jinja2 routes
 │             ├── __init__.py
-│             ├── views/
-│             │    ├── __init__.py
-│             │    └── routes.py               # Web routes for rendering templates
-│             ├── templates/                   # Optional web-specific templates
-│             └── static/                      # Optional web-specific static files
+│             └── views/
+│                  ├── __init__.py
+│                  └── routes.py               # Web routes for rendering templates
 │
-├── migrations/                                # Alembic migration scripts
+├── migrations/                                # Active Alembic migration scripts
+│    ├── env.py
+│    ├── script.py.mako
+│    └── versions/
+│
+├── migrations_old/                            # Retired migration environment (kept for reference)
 │
 ├── tests/                                     # Unit + integration tests
-│    ├── unit_tests
-│    │    ├── test_auth.py
-│    │    └── test_routes.py
 │    ├── __init__.py
-│    ├── conftest.py
-│    └── test_smoke.py
+│    ├── conftest.py                           # Shared fixtures (test DB, client, auth)
+│    ├── test_smoke.py
+│    ├── integration_tests/
+│    │    └── __init__.py
+│    └── unit_tests/
+│         ├── __init__.py
+│         ├── conftest.py
+│         ├── test_admin_users.py
+│         ├── test_agent_endpoint.py
+│         ├── test_agent_tools.py
+│         ├── test_analytics.py
+│         ├── test_auth.py
+│         ├── test_auth_jwt.py
+│         ├── test_ingest.py
+│         ├── test_intent_parser.py
+│         ├── test_item_search.py
+│         ├── test_items.py
+│         ├── test_llm_provider.py
+│         ├── test_projects.py
+│         ├── test_response_generator.py
+│         ├── test_routes.py
+│         ├── test_usage_recorder.py
+│         └── test_web_views.py
 │
 ├── utils/                                     # Utility helpers
 │    ├── __init__.py
-│    └── debug_url.py
+│    └── debug_url.py                          # Prints resolved DB URLs for debugging
+│
+├── docs/                                      # Project documentation (numbered by topic)
+│    ├── 00_overview/                          # Business scope, doc plan, roadmap
+│    ├── 01_architecture/                      # Structure and architecture overviews
+│    ├── 02_auth/                              # Auth design notes
+│    ├── 03_api/                               # API docs, secure AI query architecture
+│    ├── 04_core/                              # Data transformation steps
+│    ├── 05_db_and_migrations/                 # Schema docs, Alembic debugging
+│    ├── 06_technical/                         # Operational how-tos (admin seed, ingestion)
+│    ├── 07_checklist/                         # Roadmap checklists + archives
+│    ├── 08_diary_logs/                        # Dated development diary entries
+│    └── 09_audit_reports/                     # Phase audit reports and responses
+│
+├── .github/
+│    └── workflows/                            # GitHub Actions CI pipelines
+│         ├── ci.yml
+│         └── ci-cd.yml
 │
 ├── .env                                       # Environment variables (do not commit)
 ├── .gitignore
+├── .python-version                            # Pinned Python version for uv
+├── .pre-commit-config.yaml                    # Pre-commit hook definitions
+├── .yamllint.yml                              # YAML lint rules for workflow files
+├── alembic.ini                                # Alembic configuration
+├── dependabot.yml                             # Dependency update config
+├── setup.cfg                                  # flake8, isort, pytest, coverage config
+├── pyproject.toml                             # uv packaging + ruff/mypy config
 ├── uv.lock                                    # Locked dependencies managed by uv
-├── pyproject.toml                             # uv + modern Python packaging config
 ├── README.md
 └── LICENSE


### PR DESCRIPTION
Update docs/01_architecture/00_structure.md to match the tracked tree. Removed stale entries (core/data_upload.py, the auth/item/project service modules, templates/login.html, static/, web/templates, web/static) and added the modules that now exist: the agent pipeline services, ingestion, llm_provider, usage_recorder, api/agent.py, api/ingest.py, api/admin_users.py, config/pricing.py, config/prompts.py, core/errors.py, models/llm_usage.py, and the agent/ingest schemas. Also documented the tests, docs, and .github trees plus the root config files.

README: drop the dev-branch badge row and replace the outdated inline directory tree (still showing the pre-src app/ layout) with a link to the structure doc so the tree has a single source of truth.